### PR TITLE
Fix #5 and new presence script

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ class WifiPresenceAccessory {
       const content = yield accessory.readPresenceFile()
       const allMACs = content.trim().split('\n')
       const status = _.intersection(allMACs, accessory.mac).length > 0 ? OCCUPIED : NON_OCCUPIED
-      accessory.log(`Occupied statue: ${status}`)
+      accessory.log(`Occupied status: ${status}`)
 
       if (accessory.currentStatus !== status) {
         accessory.service.setCharacteristic(Characteristic.OccupancyDetected, status)

--- a/index.js
+++ b/index.js
@@ -8,6 +8,11 @@ let Service, Characteristic
 const OCCUPIED = 1
 const NON_OCCUPIED = 0
 
+// Stops execution for n milliseconds
+function msleep(n) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, n);
+}
+
 class WifiPresenceAccessory {
   constructor (log, config) {
     this.log = log
@@ -25,6 +30,11 @@ class WifiPresenceAccessory {
 
     fs.watch(this.presenceFile, { persistent: false }, (type, filename) => {
       if (type === 'change') {
+	// Sleep for 5 seconds to fix
+	//    Occupied statue: 0
+	//    Occupied statue: 1
+	// pattern
+	msleep(5000)
         this.isOccupied()
       }
     })

--- a/presence_server.sh
+++ b/presence_server.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/usr/sbin/arp | /bin/grep ":" | /usr/bin/awk '{ print $3 }' > /var/lib/misc/presence.wifi

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # HomeBridge Wifi Presence
 
-Detect presence in the room via wifi. This plugin is using MAC address to detect is anyone in the room or not.
+Detect presence in the room via WiFi. This plugin uses MAC addresses to detect when somebody is in a room or not, depending on which network they are connected to.
 
 ## Setup
 
@@ -22,7 +22,7 @@ Install plugin `npm install -g homebridge-wifipresence` and add accessories to h
       "accessory": "WifiPresence",
       "name": "Main Wifi",
       "room": "Living room",
-      "clients": ["MAC ADDRESS1"],
+      "clients": ["MAC ADDRESS1", "MAC ADDRESS2", ..., "MAC ADDRESSX"],
       "presenceFile": "/var/lib/misc/presence.wifi"
     }
   ],
@@ -33,11 +33,15 @@ Install plugin `npm install -g homebridge-wifipresence` and add accessories to h
 }
 ```
 
-`MAC ADDRESS1` is device wifi MAC for telling homebridge when this MAC is present, make the room occipied. It can have more than 1 MAC address.
+`MAC ADDRESSX` is the device WiFi MAC Address that you want to monitor. Once this MAC Address is connected to your network, Homebridge will then trigger the presence sensor to make the room occupied. You can add more than 1 MAC address, and they should be written in lower case (i.e.: `aa:bb:cc:dd:ee:ff`).
 
-`presenceFile` is path to list of MAC address, currently default is `/var/lib/misc/presence.wifi` same as in [presence.sh](presence.sh) script.
+`presenceFile` is the path to list of MAC addresses. Currently, the default path is `/var/lib/misc/presence.wifi`, the same as in [presence.sh](presence.sh) scripts.
 
-Run `presence.sh` file in router/access point to gathering devices MAC address from wifi interfaces.
+### Presence scripts
+Two presence scripts are provided:
+
+- `presence.sh`: To run on the router/access point to gather device MAC addresses from WiFi interfaces.
+- `presence.sh`: To run on the server where Homebridge is running, for when you do not have access or cannot run scripts on the router/access point.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ Install plugin `npm install -g homebridge-wifipresence` and add accessories to h
 Two presence scripts are provided:
 
 - `presence.sh`: To run on the router/access point to gather device MAC addresses from WiFi interfaces.
-- `presence.sh`: To run on the server where Homebridge is running, for when you do not have access or cannot run scripts on the router/access point.
+- `presence_server.sh`: To run on the server where Homebridge is running, for when you do not have access or cannot run scripts on the router/access point.
 
 ## License
 


### PR DESCRIPTION
As stated in the issue #5, a pattern similar to the following can be seen in the logs: 

```
Dec 25 15:20:11 hostname homebridge[32423]: [12/25/2019, 3:20:11 PM] [WiFiPresence] Occupied statue: 0
Dec 25 15:20:11 hostname homebridge[32423]: [12/25/2019, 3:20:12 PM] [WiFiPresence] Occupied statue: 1
```

Which makes Homebridge to mark the sensor as not triggered and then triggered after a second. If sensor notifications are enabled in HomeKit, this can generate spam.

This issue occurs due to  [`fs.watch(...)`](https://github.com/llun/homebridge-wifipresence/blob/master/index.js#L26) and how bash writes to output to a file.

When bash writes the output to a file, if the file exists, it is emptied first and then written. This makes `fs.watch` to trigger twice, first reading an empty file, so the list of MAC addresses is empty and the reading it again after being written and triggering the sensor because a client MAC address was found in the file.

To fix this, we can just simply wait a couple of seconds (5 seconds in the fix) before reading the file to make sure its not empty. This can be implemented with a `sleep` function using [Atomics.wait()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait), (available on node.js 9.3 and up).

Also, a new MAC address script is proposed. This script makes use of ARP to return a list of MAC addresses which are then parsed and added to the default file. This script is useful when the user has no access to the router/access point or when the other script does not work such as on a Raspberry Pi, which only stores the MAC address of the access point. 

This script can be run periodically using cron. The following will run the script every minute:

```
* * * * * /var/lib/homebridge/wifi.sh
```

Moreover, this new script is also documented in `readme.md` along with a couple of typos and some sentence fixes.